### PR TITLE
chore(gha): add PR helper comment workflow

### DIFF
--- a/.github/workflows/pr-autoreply.yml
+++ b/.github/workflows/pr-autoreply.yml
@@ -1,0 +1,52 @@
+name: PR helper comment
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch: {}
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post checklist comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.notice("No PR context (manual run).");
+              return;
+            }
+
+            const lines = [
+              `Thanks for the PR, @${pr.user.login}! 👋`,
+              "",
+              "**Quick checklist**",
+              "- [ ] Title follows our convention (e.g., `[component] Short summary`)",
+              "- [ ] Description explains What / Why / How",
+              "- [ ] Linked issue (e.g., `Fixes #123`)",
+              "- [ ] Screenshots for UI changes (light & dark)",
+              "- [ ] Tests + lint pass locally",
+              "- [ ] Commits signed (DCO) if required",
+              "",
+              "**Docs & Guides**",
+              "- Contributing guide: <YOUR_CONTRIBUTING_DOC_LINK>",
+              "- Code style rules: <YOUR_CODESTYLE_DOC_LINK>",
+              "- DCO info: <YOUR_DCO_DOC_LINK>",
+              "",
+              "If this PR is WIP, mark it as `Draft`."
+            ];
+
+            const body = lines.join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });


### PR DESCRIPTION
### Summary
Adds a simple GitHub Action that automatically comments on newly opened pull requests with a checklist and documentation links for contributors.

### What & Why
- Provides clear guidance for new contributors on what to include in a PR.
- Helps maintainers ensure consistent PR quality (title, linked issue, screenshots, etc.).
- Adds a `workflow_dispatch` option for manual testing via the Actions tab.

### Details
- The workflow triggers on:
  - PR **opened** or **reopened**.
  - Manual run via the **Actions → Run workflow** button.
- It uses the official [`actions/github-script`](https://github.com/actions/github-script) action.
- Once merged into `main`, every new PR will automatically receive a checklist comment.

Closed #168 