### PR TITLE
Fix: prevent newsletter subscription section overlap with divide (#152)

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -242,7 +242,7 @@ const Landing = () => {
         <br />
         <br />
         {/*optimizing this for mobile users*/}
-        <form className="w-full md:h-60 m-5" style={{ padding: "20px" }}>
+      <form className="w-full pb-16 m-5" style={{ padding: "20px" }}>
           <div className="news flex flex-col md:flex-row justify-evenly gap-8">
             <div className="flex flex-col gap-8" style={{ margin: "10px" }}>
               <div className="text-2xl md:text-4xl font-bold md:w-150 w-fit md:text-start text-center">


### PR DESCRIPTION
## Description
The newsletter subscription form was overlapping with the dividing line below it due to a fixed height (`md:h-60`) constraint.

## Solution
Removed the fixed height from the form element and added bottom padding (`pb-16`) to ensure proper spacing and prevent overlap.

## Changes

- **Type**: Bug Fix
- **File**: `Landing.jsx`
- **Details**: Adjusted layout spacing for better visual separation and responsiveness.

## Closing Issue
- Closes #152
