### PR TITLE
feat: add deploy preview workflow for Vercel

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,21 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Build site
+        run: npm run build
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-org-id: ${{ secrets.ORG_ID }}
+          vercel-project-id: ${{ secrets.PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ firebase-debug.*
 # Local configs
 *.local
 *.envrc
+.vercel


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for Vercel PR deploy previews, solving [issue #289](https://github.com/SASTxNST/Website_SAST/issues/289).

Explains: triggers on pull_request, builds with npm, posts preview link, secrets required: VERCEL_TOKEN, ORG_ID, PROJECT_ID.

Reference the steps you followed if you like.

