### PR TITLE
Fix Navbar active link highlighting

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import "../index.css";
 import logo from "../Landing_media/SAST.png";
 
@@ -44,9 +44,9 @@ const Navbar = () => {
           className="container header-content"
           style={{ position: "relative", width: "100%" }}
         >
-          <Link to="/" className="logo" onClick={closeMenu}>
+          <NavLink to="/" className="logo" onClick={closeMenu}>
             <img src={logo} alt="Logo" width="60" height="60" className="rounded-md" />
-          </Link>
+          </NavLink>
 
           {isMobile && (
             <button
@@ -65,23 +65,23 @@ const Navbar = () => {
             <ul className="nav-links">
 
              
-              <li><Link to="/docs" onClick={closeMenu}>Docs</Link></li>
+              <li><NavLink to="/docs" onClick={closeMenu}>Docs</NavLink></li>
 
               <li>
-                <Link to="/" onClick={closeMenu}>Home</Link>
+                <NavLink to="/" onClick={closeMenu}>Home</NavLink>
               </li>
 
               <li>
-                <Link to="/newsletter" onClick={closeMenu}>Newsletter</Link>
+                <NavLink to="/newsletter" onClick={closeMenu}>Newsletter</NavLink>
               </li>
               <li>
-                <Link to="/events" onClick={closeMenu}>Events</Link>
+                <NavLink to="/events" onClick={closeMenu}>Events</NavLink>
               </li>
               <li>
-                <Link to="/projects" onClick={closeMenu}>Projects</Link>
+                <NavLink to="/projects" onClick={closeMenu}>Projects</NavLink>
               </li>
               <li>
-                <Link to="/community/members" onClick={closeMenu}>Members</Link>
+                <NavLink to="/community/members" onClick={closeMenu}>Members</NavLink>
               </li>
                <li className="nebula-link">
                 <a href="https://nebula.sastclub.tech/" target="_blank" rel="noopener noreferrer">
@@ -89,16 +89,16 @@ const Navbar = () => {
                 </a>
               </li>
               <li>
-                <Link to="/contributors" onClick={closeMenu}>Contributors</Link>
+                <NavLink to="/contributors" onClick={closeMenu}>Contributors</NavLink>
               </li>
               <li>
-                <Link to="/register" onClick={closeMenu}>Register</Link>
+                <NavLink to="/register" onClick={closeMenu}>Register</NavLink>
               </li>
               <li>
-                <Link to="/news" onClick={closeMenu}>Astronomy News</Link>
+                <NavLink to="/news" onClick={closeMenu}>Astronomy News</NavLink>
               </li>
               <li>
-                <Link to="/track" onClick={closeMenu}>Track</Link>
+                <NavLink to="/track" onClick={closeMenu}>Track</NavLink>
               </li>
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,11 @@ body {
 .main-nav a:hover {
   color: var(--color-text);
 }
+.main-nav a.active{
+  color: var(--color-text);
+  font-weight: 600;
+}
+
 
 .contact-button {
   padding: 0.75rem 1.5rem;


### PR DESCRIPTION
This pull request adds active link highlighting to the Navbar, so users can easily see which page they are on.
Changes in Navbar component:
- Replaced <Link> with <NavLink> for active route detection
- Added CSS for active links:
  .main-nav a.active {
    color: var(--color-text);
    font-weight: 600;
  }
Before:
<img width="1857" height="132" alt="image" src="https://github.com/user-attachments/assets/754088a3-65c5-4c30-9bad-32112f52c123" />
After:
<img width="1857" height="120" alt="image" src="https://github.com/user-attachments/assets/9042868b-5b5d-4df8-a751-421d455fb2e3" />
Closes #311 