### PR TITLE
fixed overlapping header in contributors and member's section

### DIFF
--- a/src/pages/ContributorProfile.jsx
+++ b/src/pages/ContributorProfile.jsx
@@ -63,7 +63,7 @@ export default function ContributorProfile() {
 
   return (
     <article
-      className="w-full"
+      className="w-full pt-30"
       style={{
         paddingLeft: "1.5rem",
         paddingRight: "1.5rem",
@@ -83,7 +83,7 @@ export default function ContributorProfile() {
       </div>
 
       <div
-        className="text-center font-semibold tracking-wide text-emerald-200/90"
+        className="text-center font-bold text-[50px] tracking-wide text-emerald-200/90"
         style={{ marginBottom: "1.25rem" }}
       >
         SAST Contributor

--- a/src/pages/MemberProfile.jsx
+++ b/src/pages/MemberProfile.jsx
@@ -63,7 +63,7 @@ export default function MemberProfile() {
 
   return (
     <article
-      className="w-full"
+      className="w-full pt-30"
       style={{
         paddingLeft: "1.5rem",
         paddingRight: "1.5rem",
@@ -83,8 +83,11 @@ export default function MemberProfile() {
       </div>
 
       <div
-        className="text-center font-semibold tracking-wide text-emerald-200/90"
-        style={{ marginBottom: "1.25rem" }}
+        className="text-center font-bold text-[50px] tracking-wide text-emerald-200/90 pb-5 font-family-['arial']"
+        style={{ marginBottom: "1.25rem"
+        }
+      
+      }
       >
         SAST Community Member
       </div>


### PR DESCRIPTION
<img width="2998" height="1628" alt="image" src="https://github.com/user-attachments/assets/9f2d4709-87d9-43d4-9bfb-470c13aea756" />
now the overlapping header is fixed

Closes #343 