### PR TITLE
[BUG] Member Page Content Overlapping with Header #361

### DIFF
--- a/src/pages/MemberProfile.jsx
+++ b/src/pages/MemberProfile.jsx
@@ -66,8 +66,8 @@ export default function MemberProfile() {
       className="w-full"
       style={{
         paddingLeft: "1.5rem",
-        paddingRight: "1.5rem",
-        paddingBottom: "6rem",
+        paddingBottom: "5rem",
+        paddingTop: "8rem"
       }}
     >
       <div
@@ -83,7 +83,7 @@ export default function MemberProfile() {
       </div>
 
       <div
-        className="text-center font-semibold tracking-wide text-emerald-200/90"
+        className="text-center text-2xl font-semibold tracking-wide text-emerald-200/90"
         style={{ marginBottom: "1.25rem" }}
       >
         SAST Community Member
@@ -95,6 +95,7 @@ export default function MemberProfile() {
           maxWidth: "1150px",
           margin: "0 auto",
           width: "100%",
+          paddingRight: "1rem",
         }}
       >
         <div
@@ -133,7 +134,7 @@ export default function MemberProfile() {
               className="text-2xl italic text-emerald-300/90"
               style={{ marginTop: "0.6rem" }}
             >
-              Member
+              {m.role}
             </p>
           )}
 


### PR DESCRIPTION
Fixing Issue - #361 
This pull request makes several UI improvements to the `MemberProfile` page, focusing on layout adjustments and enhanced display of member information. The most notable changes are improved padding, font styling, and dynamic role display.

**UI and Layout Adjustments:**

* Adjusted padding values in the main container to refine vertical spacing and layout (`paddingBottom` from 6rem to 5rem, added `paddingTop: 8rem`).
* Added `paddingRight: 1rem` to the inner container for better horizontal spacing.

**Typography and Display Enhancements:**

* Increased the font size of the "SAST Community Member" heading to `text-2xl` for better emphasis.
* Changed the displayed member role from the static text "Member" to the dynamic value of `m.role`, making the profile more personalized.

Updated Page:
<img width="1510" height="815" alt="image" src="https://github.com/user-attachments/assets/6132d958-b365-4315-b2a3-dd4da889f1b4" />
