### PR TITLE
fix: Prabhav Jain avatar

### DIFF
--- a/src/data/contributors.json
+++ b/src/data/contributors.json
@@ -217,7 +217,7 @@
     "role": "Contributor",
     "location": "Jabalpur, Madhya Pradesh",
     "bio": "\"Leave me alone, I know what I’m doing.\" - Kimi Raikkonen",
-    "avatarUrl": "https://drive.google.com/file/d/15t3KlqmnwtUUxarVa7Y7tan8dMErlmQR/view?usp=sharing",
+    "avatarUrl": "https://avatars.githubusercontent.com/u/205253082?v=4",
     "links": {
       "github": "https://github.com/Prabhav1437",
       "x": "https://x.com/Prabhav15627081",


### PR DESCRIPTION
Use direct avatars.githubusercontent.com URL so the avatar loads reliably (avoids redirect/drive link).